### PR TITLE
Remove Compose version line

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   app:
     build:


### PR DESCRIPTION
## Summary
- remove the `version: '3.8'` line at the top of `docker-compose.yml`

## Testing
- `composer install --no-progress --no-interaction` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_687bbadecd408333bf4f53cc019e1e7b