### PR TITLE
Add Backpack CMS setup

### DIFF
--- a/.cline/scratchpad.md
+++ b/.cline/scratchpad.md
@@ -157,6 +157,13 @@ Evidence: backend/package.json, backend/vite.config.js, backend/resources/js/app
 Next Steps: Integrate Vue Router and Pinia as development continues
 Updated: 2025-07-19
 
+Task: Configure Backpack CMS with custom admin panels
+Status: Awaiting Confirmation
+Progress: Added Backpack dependency, service provider, configuration, CRUD controllers, and routes
+Evidence: backend/composer.json, backend/bootstrap/providers.php, backend/config/backpack/base.php, backend/app/Http/Controllers/Admin/*CrudController.php, backend/routes/backpack/custom.php
+Next Steps: After confirmation, begin implementing API endpoints for frontend consumption
+Updated: 2025-07-19
+
 
 *This section will be populated by the executor during development with specific questions, blockers, or requests for clarification.*
 

--- a/backend/app/Http/Controllers/Admin/BlogCategoryCrudController.php
+++ b/backend/app/Http/Controllers/Admin/BlogCategoryCrudController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Models\BlogCategory;
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
+
+class BlogCategoryCrudController extends CrudController
+{
+    public function setup(): void
+    {
+        CRUD::setModel(BlogCategory::class);
+        CRUD::setRoute(config('backpack.base.route_prefix', 'admin').'/blogcategories');
+        CRUD::setEntityNameStrings('blog category', 'blog categories');
+    }
+
+    protected function setupListOperation(): void
+    {
+        CRUD::column('name');
+        CRUD::column('slug');
+    }
+
+    protected function setupCreateOperation(): void
+    {
+        CRUD::field('name');
+        CRUD::field('slug');
+    }
+}

--- a/backend/app/Http/Controllers/Admin/InquiryCrudController.php
+++ b/backend/app/Http/Controllers/Admin/InquiryCrudController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Models\Inquiry;
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
+
+class InquiryCrudController extends CrudController
+{
+    public function setup(): void
+    {
+        CRUD::setModel(Inquiry::class);
+        CRUD::setRoute(config('backpack.base.route_prefix', 'admin').'/inquiries');
+        CRUD::setEntityNameStrings('inquiry', 'inquiries');
+    }
+
+    protected function setupListOperation(): void
+    {
+        CRUD::column('name');
+        CRUD::column('email');
+    }
+
+    protected function setupCreateOperation(): void
+    {
+        CRUD::field('name');
+        CRUD::field('email');
+        CRUD::field('message')->type('textarea');
+    }
+}

--- a/backend/app/Http/Controllers/Admin/NewsletterSubscriberCrudController.php
+++ b/backend/app/Http/Controllers/Admin/NewsletterSubscriberCrudController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Models\NewsletterSubscriber;
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
+
+class NewsletterSubscriberCrudController extends CrudController
+{
+    public function setup(): void
+    {
+        CRUD::setModel(NewsletterSubscriber::class);
+        CRUD::setRoute(config('backpack.base.route_prefix', 'admin').'/newsletter-subscribers');
+        CRUD::setEntityNameStrings('subscriber', 'newsletter subscribers');
+    }
+
+    protected function setupListOperation(): void
+    {
+        CRUD::column('email');
+        CRUD::column('created_at');
+    }
+
+    protected function setupCreateOperation(): void
+    {
+        CRUD::field('email');
+    }
+}

--- a/backend/app/Http/Controllers/Admin/PostCrudController.php
+++ b/backend/app/Http/Controllers/Admin/PostCrudController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Models\Post;
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
+
+class PostCrudController extends CrudController
+{
+    public function setup(): void
+    {
+        CRUD::setModel(Post::class);
+        CRUD::setRoute(config('backpack.base.route_prefix', 'admin').'/posts');
+        CRUD::setEntityNameStrings('post', 'posts');
+    }
+
+    protected function setupListOperation(): void
+    {
+        CRUD::column('title');
+        CRUD::column('slug');
+        CRUD::column('published_at');
+    }
+
+    protected function setupCreateOperation(): void
+    {
+        CRUD::field('blog_category_id');
+        CRUD::field('title');
+        CRUD::field('slug');
+        CRUD::field('excerpt');
+        CRUD::field('body')->type('textarea');
+        CRUD::field('published_at')->type('datetime');
+    }
+}

--- a/backend/app/Http/Controllers/Admin/ProjectCategoryCrudController.php
+++ b/backend/app/Http/Controllers/Admin/ProjectCategoryCrudController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Models\ProjectCategory;
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
+
+class ProjectCategoryCrudController extends CrudController
+{
+    public function setup(): void
+    {
+        CRUD::setModel(ProjectCategory::class);
+        CRUD::setRoute(config('backpack.base.route_prefix', 'admin').'/projectcategories');
+        CRUD::setEntityNameStrings('project category', 'project categories');
+    }
+
+    protected function setupListOperation(): void
+    {
+        CRUD::column('name');
+        CRUD::column('slug');
+    }
+
+    protected function setupCreateOperation(): void
+    {
+        CRUD::field('name');
+        CRUD::field('slug');
+    }
+}

--- a/backend/app/Http/Controllers/Admin/ProjectCrudController.php
+++ b/backend/app/Http/Controllers/Admin/ProjectCrudController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Models\Project;
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
+
+class ProjectCrudController extends CrudController
+{
+    public function setup(): void
+    {
+        CRUD::setModel(Project::class);
+        CRUD::setRoute(config('backpack.base.route_prefix', 'admin').'/projects');
+        CRUD::setEntityNameStrings('project', 'projects');
+    }
+
+    protected function setupListOperation(): void
+    {
+        CRUD::column('title');
+        CRUD::column('slug');
+    }
+
+    protected function setupCreateOperation(): void
+    {
+        CRUD::field('title');
+        CRUD::field('slug');
+        CRUD::field('excerpt');
+        CRUD::field('description')->type('textarea');
+    }
+}

--- a/backend/app/Http/Controllers/Admin/TagCrudController.php
+++ b/backend/app/Http/Controllers/Admin/TagCrudController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Models\Tag;
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
+
+class TagCrudController extends CrudController
+{
+    public function setup(): void
+    {
+        CRUD::setModel(Tag::class);
+        CRUD::setRoute(config('backpack.base.route_prefix', 'admin').'/tags');
+        CRUD::setEntityNameStrings('tag', 'tags');
+    }
+
+    protected function setupListOperation(): void
+    {
+        CRUD::column('name');
+        CRUD::column('slug');
+    }
+
+    protected function setupCreateOperation(): void
+    {
+        CRUD::field('name');
+        CRUD::field('slug');
+    }
+}

--- a/backend/app/Http/Controllers/Admin/TechnologyCrudController.php
+++ b/backend/app/Http/Controllers/Admin/TechnologyCrudController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Models\Technology;
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Backpack\CRUD\app\Library\CrudPanel\CrudPanelFacade as CRUD;
+
+class TechnologyCrudController extends CrudController
+{
+    public function setup(): void
+    {
+        CRUD::setModel(Technology::class);
+        CRUD::setRoute(config('backpack.base.route_prefix', 'admin').'/technologies');
+        CRUD::setEntityNameStrings('technology', 'technologies');
+    }
+
+    protected function setupListOperation(): void
+    {
+        CRUD::column('name');
+        CRUD::column('slug');
+    }
+
+    protected function setupCreateOperation(): void
+    {
+        CRUD::field('name');
+        CRUD::field('slug');
+    }
+}

--- a/backend/bootstrap/providers.php
+++ b/backend/bootstrap/providers.php
@@ -2,4 +2,5 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    Backpack\CRUD\BackpackServiceProvider::class,
 ];

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -8,7 +8,8 @@
     "require": {
         "php": "^8.2",
         "laravel/framework": "^12.0",
-        "laravel/tinker": "^2.10.1"
+        "laravel/tinker": "^2.10.1",
+        "backpack/crud": "^6.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/backend/config/backpack/base.php
+++ b/backend/config/backpack/base.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'route_prefix' => env('BACKPACK_ROUTE_PREFIX', 'admin'),
+    'middleware' => [
+        'web',
+        'auth',
+    ],
+];

--- a/backend/routes/backpack/custom.php
+++ b/backend/routes/backpack/custom.php
@@ -1,0 +1,16 @@
+<?php
+use Illuminate\Support\Facades\Route;
+
+Route::group([
+    'prefix' => config('backpack.base.route_prefix', 'admin'),
+    'middleware' => config('backpack.base.middleware', ['web', 'auth']),
+], function () {
+    Route::crud('projects', \App\Http\Controllers\Admin\ProjectCrudController::class);
+    Route::crud('project-categories', \App\Http\Controllers\Admin\ProjectCategoryCrudController::class);
+    Route::crud('technologies', \App\Http\Controllers\Admin\TechnologyCrudController::class);
+    Route::crud('blog-categories', \App\Http\Controllers\Admin\BlogCategoryCrudController::class);
+    Route::crud('posts', \App\Http\Controllers\Admin\PostCrudController::class);
+    Route::crud('tags', \App\Http\Controllers\Admin\TagCrudController::class);
+    Route::crud('inquiries', \App\Http\Controllers\Admin\InquiryCrudController::class);
+    Route::crud('newsletter-subscribers', \App\Http\Controllers\Admin\NewsletterSubscriberCrudController::class);
+});

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -5,3 +5,5 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {
     return view('welcome');
 });
+
+require __DIR__.'/backpack/custom.php';


### PR DESCRIPTION
## Summary
- integrate Backpack CRUD package into Laravel backend
- register Backpack service provider
- add Backpack config with route prefix and middleware
- scaffold CRUD controllers for admin panel
- register admin routes and include them in web routes
- document progress in scratchpad

## Testing
- `composer test` *(fails: missing vendor directory)*

------
https://chatgpt.com/codex/tasks/task_e_687c117992548333bf172f530fb2136c