### PR TITLE
Implement initial API endpoints

### DIFF
--- a/.cline/scratchpad.md
+++ b/.cline/scratchpad.md
@@ -43,7 +43,7 @@
 - [x] Initialize Laravel 11 project with Docker configuration
 - [x] Set up database schema and migrations for core entities
 - [ ] Configure Backpack CMS with custom admin panels
-- [ ] Create API endpoints for frontend consumption
+- [x] Create API endpoints for frontend consumption
 - [ ] Implement authentication system and API rate limiting
 
 - **Frontend Foundation**
@@ -132,7 +132,7 @@
 - **Polish & Launch:** Not Started
 
 **Current Phase:** Phase 1 - Foundation & Infrastructure
-**Overall Progress:** 0/32 tasks completed (0%)
+**Overall Progress:** 5/32 tasks completed (16%)
 **Timeline Status:** On track for 12-week delivery
 
 ## Executor's Feedback or Assistance Requests
@@ -162,6 +162,13 @@ Status: Awaiting Confirmation
 Progress: Added Backpack dependency, service provider, configuration, CRUD controllers, and routes
 Evidence: backend/composer.json, backend/bootstrap/providers.php, backend/config/backpack/base.php, backend/app/Http/Controllers/Admin/*CrudController.php, backend/routes/backpack/custom.php
 Next Steps: After confirmation, begin implementing API endpoints for frontend consumption
+Updated: 2025-07-19
+
+Task: Create API endpoints for frontend consumption
+Status: Awaiting Confirmation
+Progress: Implemented RESTful API routes, controllers, resources and tests
+Evidence: backend/routes/api.php, backend/app/Http/Controllers/Api/, backend/app/Http/Resources/, backend/tests/Feature/*ApiTest.php
+Next Steps: Await confirmation to proceed with authentication and rate limiting
 Updated: 2025-07-19
 
 

--- a/backend/app/Http/Controllers/Api/InquiryController.php
+++ b/backend/app/Http/Controllers/Api/InquiryController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Inquiry;
+use Illuminate\Http\Request;
+
+class InquiryController extends Controller
+{
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|email',
+            'message' => 'required|string',
+        ]);
+
+        Inquiry::create($data);
+
+        return response()->json(['message' => 'Inquiry received'], 201);
+    }
+}

--- a/backend/app/Http/Controllers/Api/NewsletterController.php
+++ b/backend/app/Http/Controllers/Api/NewsletterController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\NewsletterSubscriber;
+use Illuminate\Http\Request;
+
+class NewsletterController extends Controller
+{
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'email' => 'required|email|unique:newsletter_subscribers,email',
+        ]);
+
+        NewsletterSubscriber::create($data);
+
+        return response()->json(['message' => 'Subscribed'], 201);
+    }
+}

--- a/backend/app/Http/Controllers/Api/PostController.php
+++ b/backend/app/Http/Controllers/Api/PostController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\PostResource;
+use App\Models\Post;
+
+class PostController extends Controller
+{
+    public function index()
+    {
+        return PostResource::collection(Post::whereNotNull('published_at')->get());
+    }
+
+    public function show(Post $post)
+    {
+        return new PostResource($post);
+    }
+}

--- a/backend/app/Http/Controllers/Api/ProjectController.php
+++ b/backend/app/Http/Controllers/Api/ProjectController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\ProjectResource;
+use App\Models\Project;
+
+class ProjectController extends Controller
+{
+    public function index()
+    {
+        return ProjectResource::collection(Project::all());
+    }
+
+    public function show(Project $project)
+    {
+        return new ProjectResource($project);
+    }
+}

--- a/backend/app/Http/Resources/PostResource.php
+++ b/backend/app/Http/Resources/PostResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PostResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     */
+    public function toArray($request): array
+    {
+        return [
+            'title' => $this->title,
+            'slug' => $this->slug,
+            'excerpt' => $this->excerpt,
+            'body' => $this->body,
+            'published_at' => optional($this->published_at)->toIso8601String(),
+        ];
+    }
+}

--- a/backend/app/Http/Resources/ProjectResource.php
+++ b/backend/app/Http/Resources/ProjectResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ProjectResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     */
+    public function toArray($request): array
+    {
+        return [
+            'title' => $this->title,
+            'slug' => $this->slug,
+            'excerpt' => $this->excerpt,
+            'description' => $this->description,
+            'featured_image' => $this->featured_image,
+        ];
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/backend/database/factories/PostFactory.php
+++ b/backend/database/factories/PostFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Post;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class PostFactory extends Factory
+{
+    protected $model = Post::class;
+
+    public function definition(): array
+    {
+        $title = $this->faker->sentence;
+        return [
+            'title' => $title,
+            'slug' => Str::slug($title.'-'.uniqid()),
+            'excerpt' => $this->faker->paragraph,
+            'body' => $this->faker->paragraph,
+            'published_at' => now(),
+        ];
+    }
+}

--- a/backend/database/factories/ProjectFactory.php
+++ b/backend/database/factories/ProjectFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Project;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class ProjectFactory extends Factory
+{
+    protected $model = Project::class;
+
+    public function definition(): array
+    {
+        $title = $this->faker->sentence;
+        return [
+            'title' => $title,
+            'slug' => Str::slug($title.'-'.uniqid()),
+            'excerpt' => $this->faker->paragraph,
+            'description' => $this->faker->paragraph,
+            'featured_image' => null,
+        ];
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\ProjectController;
+use App\Http\Controllers\Api\PostController;
+use App\Http\Controllers\Api\InquiryController;
+use App\Http\Controllers\Api\NewsletterController;
+
+Route::get('/projects', [ProjectController::class, 'index']);
+Route::get('/projects/{project:slug}', [ProjectController::class, 'show']);
+
+Route::get('/posts', [PostController::class, 'index']);
+Route::get('/posts/{post:slug}', [PostController::class, 'show']);
+
+Route::post('/inquiries', [InquiryController::class, 'store']);
+Route::post('/subscribe', [NewsletterController::class, 'store']);

--- a/backend/tests/Feature/InquiryApiTest.php
+++ b/backend/tests/Feature/InquiryApiTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InquiryApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_store_inquiry()
+    {
+        $response = $this->postJson('/api/inquiries', [
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'message' => 'Hello',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('inquiries', ['email' => 'john@example.com']);
+    }
+}

--- a/backend/tests/Feature/NewsletterApiTest.php
+++ b/backend/tests/Feature/NewsletterApiTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class NewsletterApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_subscribe()
+    {
+        $response = $this->postJson('/api/subscribe', [
+            'email' => 'john@example.com',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('newsletter_subscribers', ['email' => 'john@example.com']);
+    }
+}

--- a/backend/tests/Feature/PostApiTest.php
+++ b/backend/tests/Feature/PostApiTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Post;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PostApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_posts_index()
+    {
+        Post::factory()->count(3)->create();
+
+        $response = $this->getJson('/api/posts');
+
+        $response->assertStatus(200)->assertJsonCount(3);
+    }
+
+    public function test_post_show()
+    {
+        $post = Post::factory()->create();
+
+        $response = $this->getJson('/api/posts/'.$post->slug);
+
+        $response->assertStatus(200)->assertJsonFragment(['slug' => $post->slug]);
+    }
+}

--- a/backend/tests/Feature/ProjectApiTest.php
+++ b/backend/tests/Feature/ProjectApiTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Project;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProjectApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_projects_index()
+    {
+        Project::factory()->count(2)->create();
+
+        $response = $this->getJson('/api/projects');
+
+        $response->assertStatus(200)->assertJsonCount(2);
+    }
+
+    public function test_project_show()
+    {
+        $project = Project::factory()->create();
+
+        $response = $this->getJson('/api/projects/'.$project->slug);
+
+        $response->assertStatus(200)->assertJsonFragment(['slug' => $project->slug]);
+    }
+}


### PR DESCRIPTION
## Summary
- add REST API controllers with project, post, inquiry and newsletter endpoints
- expose routes in `routes/api.php` and enable them in `bootstrap/app.php`
- add API resources for projects and posts
- add model factories and feature tests
- update scratchpad progress

## Testing
- `php vendor/bin/phpunit --filter ProjectApiTest --stop-on-failure` *(fails: Could not open input file: vendor/bin/phpunit)*

------
https://chatgpt.com/codex/tasks/task_e_687c1600bf4c8333a67591264d794da5