### PR TITLE
Implement authentication with Sanctum

### DIFF
--- a/.cline/scratchpad.md
+++ b/.cline/scratchpad.md
@@ -44,7 +44,7 @@
 - [x] Set up database schema and migrations for core entities
 - [ ] Configure Backpack CMS with custom admin panels
 - [x] Create API endpoints for frontend consumption
-- [ ] Implement authentication system and API rate limiting
+- [x] Implement authentication system and API rate limiting
 
 - **Frontend Foundation**
 - [x] Initialize Vue 3 + Vite project with TypeScript
@@ -169,6 +169,13 @@ Status: Awaiting Confirmation
 Progress: Implemented RESTful API routes, controllers, resources and tests
 Evidence: backend/routes/api.php, backend/app/Http/Controllers/Api/, backend/app/Http/Resources/, backend/tests/Feature/*ApiTest.php
 Next Steps: Await confirmation to proceed with authentication and rate limiting
+Updated: 2025-07-19
+
+Task: Implement authentication system and API rate limiting
+Status: Awaiting Confirmation
+Progress: Added Sanctum package, middleware configuration, auth routes and controllers; created tests for authentication and rate limits
+Evidence: backend/composer.json, backend/bootstrap/app.php, backend/routes/api.php, backend/app/Http/Controllers/Api/AuthController.php, backend/tests/Feature/AuthApiTest.php, backend/tests/Feature/RateLimitTest.php
+Next Steps: Review and confirm implementation
 Updated: 2025-07-19
 
 

--- a/backend/app/Http/Controllers/Api/AuthController.php
+++ b/backend/app/Http/Controllers/Api/AuthController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+
+class AuthController extends Controller
+{
+    public function register(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:users,email',
+            'password' => 'required|string|min:8|confirmed',
+        ]);
+
+        $user = User::create([
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'password' => Hash::make($data['password']),
+        ]);
+
+        $token = $user->createToken('api')->plainTextToken;
+
+        return response()->json(['token' => $token], 201);
+    }
+
+    public function login(Request $request)
+    {
+        $credentials = $request->validate([
+            'email' => 'required|email',
+            'password' => 'required',
+        ]);
+
+        if (!Auth::attempt($credentials)) {
+            return response()->json(['message' => 'Invalid credentials'], 401);
+        }
+
+        $token = $request->user()->createToken('api')->plainTextToken;
+
+        return response()->json(['token' => $token]);
+    }
+
+    public function logout(Request $request)
+    {
+        $request->user()->currentAccessToken()->delete();
+
+        return response()->json(['message' => 'Logged out']);
+    }
+}

--- a/backend/app/Http/Middleware/Authenticate.php
+++ b/backend/app/Http/Middleware/Authenticate.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Auth\Middleware\Authenticate as Middleware;
+
+class Authenticate extends Middleware
+{
+    protected function redirectTo($request): ?string
+    {
+        return null;
+    }
+}

--- a/backend/app/Http/Middleware/EncryptCookies.php
+++ b/backend/app/Http/Middleware/EncryptCookies.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Cookie\Middleware\EncryptCookies as Middleware;
+
+class EncryptCookies extends Middleware
+{
+    protected $except = [];
+}

--- a/backend/app/Http/Middleware/VerifyCsrfToken.php
+++ b/backend/app/Http/Middleware/VerifyCsrfToken.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as Middleware;
+
+class VerifyCsrfToken extends Middleware
+{
+    /**
+     * The URIs that should be excluded from CSRF verification.
+     *
+     * @var array<int, string>
+     */
+    protected $except = [];
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -12,7 +12,16 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'auth' => App\Http\Middleware\Authenticate::class,
+            'throttle' => Illuminate\Routing\Middleware\ThrottleRequests::class,
+        ]);
+
+        $middleware->group('api', [
+            Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+            'throttle:60,1',
+            Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/backend/bootstrap/providers.php
+++ b/backend/bootstrap/providers.php
@@ -3,4 +3,5 @@
 return [
     App\Providers\AppServiceProvider::class,
     Backpack\CRUD\BackpackServiceProvider::class,
+    Laravel\Sanctum\SanctumServiceProvider::class,
 ];

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -9,7 +9,8 @@
         "php": "^8.2",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
-        "backpack/crud": "^6.0"
+        "backpack/crud": "^6.0",
+        "laravel/sanctum": "^4.1"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/backend/config/sanctum.php
+++ b/backend/config/sanctum.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
+        '%s%s',
+        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
+        env('APP_URL') ? ','.parse_url(env('APP_URL'), PHP_URL_HOST) : ''
+    ))),
+
+    'expiration' => null,
+
+    'middleware' => [
+        'verify_csrf_token' => App\Http\Middleware\VerifyCsrfToken::class,
+        'encrypt_cookies' => App\Http\Middleware\EncryptCookies::class,
+    ],
+];

--- a/backend/database/migrations/2025_07_19_000010_create_personal_access_tokens_table.php
+++ b/backend/database/migrations/2025_07_19_000010_create_personal_access_tokens_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Api\ProjectController;
 use App\Http\Controllers\Api\PostController;
 use App\Http\Controllers\Api\InquiryController;
 use App\Http\Controllers\Api\NewsletterController;
+use App\Http\Controllers\Api\AuthController;
 
 Route::get('/projects', [ProjectController::class, 'index']);
 Route::get('/projects/{project:slug}', [ProjectController::class, 'show']);
@@ -14,3 +15,7 @@ Route::get('/posts/{post:slug}', [PostController::class, 'show']);
 
 Route::post('/inquiries', [InquiryController::class, 'store']);
 Route::post('/subscribe', [NewsletterController::class, 'store']);
+
+Route::post('/register', [AuthController::class, 'register']);
+Route::post('/login', [AuthController::class, 'login']);
+Route::middleware('auth:sanctum')->post('/logout', [AuthController::class, 'logout']);

--- a/backend/tests/Feature/AuthApiTest.php
+++ b/backend/tests/Feature/AuthApiTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class AuthApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_register_and_login()
+    {
+        $response = $this->postJson('/api/register', [
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+        $response->assertStatus(201)->assertJsonStructure(['token']);
+        $this->assertDatabaseHas('users', ['email' => 'john@example.com']);
+
+        $login = $this->postJson('/api/login', [
+            'email' => 'john@example.com',
+            'password' => 'password',
+        ]);
+
+        $login->assertStatus(200)->assertJsonStructure(['token']);
+    }
+
+    public function test_logout_requires_auth()
+    {
+        $user = User::factory()->create([
+            'password' => Hash::make('secret'),
+        ]);
+        $token = $user->createToken('api')->plainTextToken;
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token,
+        ])->postJson('/api/logout');
+
+        $response->assertStatus(200);
+    }
+}

--- a/backend/tests/Feature/RateLimitTest.php
+++ b/backend/tests/Feature/RateLimitTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RateLimitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_api_rate_limiting()
+    {
+        for ($i = 0; $i < 60; $i++) {
+            $this->getJson('/api/posts')->assertStatus(200);
+        }
+
+        $this->getJson('/api/posts')->assertStatus(429);
+    }
+}


### PR DESCRIPTION
## Summary
- add Laravel Sanctum dependency and provider
- create personal access token migration
- add Sanctum middleware configuration
- build Auth API controller with register/login/logout
- add API rate limiting
- configure new tests
- document progress in scratchpad

## Testing
- `composer test` *(fails: missing vendor directory)*

------
https://chatgpt.com/codex/tasks/task_e_687c1ffa559483338b09292c6cb9550f