### PR TITLE
Disable wrapping in PostResource and ProjectResource

### DIFF
--- a/backend/app/Http/Resources/PostResource.php
+++ b/backend/app/Http/Resources/PostResource.php
@@ -8,6 +8,12 @@ use Illuminate\Http\Resources\Json\JsonResource;
 class PostResource extends JsonResource
 {
     /**
+     * Disable the default data wrapper.
+     *
+     * @var null
+     */
+    public static $wrap = null;
+    /**
      * Transform the resource into an array.
      */
     public function toArray($request): array

--- a/backend/app/Http/Resources/ProjectResource.php
+++ b/backend/app/Http/Resources/ProjectResource.php
@@ -8,6 +8,12 @@ use Illuminate\Http\Resources\Json\JsonResource;
 class ProjectResource extends JsonResource
 {
     /**
+     * Disable the default data wrapper.
+     *
+     * @var null
+     */
+    public static $wrap = null;
+    /**
      * Transform the resource into an array.
      */
     public function toArray($request): array


### PR DESCRIPTION
## Summary
- disable the `data` wrapper for post and project API resources

## Testing
- `composer test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d134893908333ba313c6bef4aedc5