### PR TITLE
Update README for backend install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,18 @@ This repository contains the source code for the **CoderStew** freelance web dev
 ## Development Setup
 
 1. Ensure you have [Docker](https://docs.docker.com/get-docker/) and Docker Compose installed.
-2. From the repository root, start the containers:
+2. Navigate to the `backend/` directory and install dependencies:
+
+```bash
+cd backend
+composer install
+npm install # if Node packages are needed
+
+# Run backend tests from this directory
+composer test
+```
+
+3. From the repository root, start the containers:
 
 ```bash
 docker compose up -d


### PR DESCRIPTION
## Summary
- document how to install PHP/Node packages in `backend/`
- show where to run `composer test`

## Testing
- `composer install` *(fails: Required package is not present)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687d134b50f0833383fe9ff0b9cdc554