### PR TITLE
Fix API resource wrapping

### DIFF
--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +20,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        JsonResource::withoutWrapping();
     }
 }


### PR DESCRIPTION
## Summary
- configure `JsonResource` to globally disable data wrapping

## Testing
- `composer test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_687d1ba4fccc83338059f9ba2a71bbf3