### PR TITLE
Fix API test assertions for data collection

### DIFF
--- a/backend/tests/Feature/PostApiTest.php
+++ b/backend/tests/Feature/PostApiTest.php
@@ -16,7 +16,7 @@ class PostApiTest extends TestCase
 
         $response = $this->getJson('/api/posts');
 
-        $response->assertStatus(200)->assertJsonCount(3);
+        $response->assertStatus(200)->assertJsonCount(3, 'data');
     }
 
     public function test_post_show()

--- a/backend/tests/Feature/ProjectApiTest.php
+++ b/backend/tests/Feature/ProjectApiTest.php
@@ -16,7 +16,7 @@ class ProjectApiTest extends TestCase
 
         $response = $this->getJson('/api/projects');
 
-        $response->assertStatus(200)->assertJsonCount(2);
+        $response->assertStatus(200)->assertJsonCount(2, 'data');
     }
 
     public function test_project_show()


### PR DESCRIPTION
## Summary
- ensure post and project API tests specify the `data` path when asserting item counts

## Testing
- `composer test` *(fails: missing vendor autoload)*

------
https://chatgpt.com/codex/tasks/task_e_687d1ba74774833386d05fbeb34f9774