### PR TITLE
Add Node service and compose tests

### DIFF
--- a/.cline/scratchpad.md
+++ b/.cline/scratchpad.md
@@ -118,7 +118,7 @@
 ### Phase 1: Foundation & Infrastructure
 - **Backend Setup & Core API:** In Progress (2025-07-18)
 - **Frontend Foundation:** In Progress (2025-07-19)
-- **Infrastructure:** Not Started
+- **Infrastructure:** In Progress (2025-07-20)
 
 ### Phase 2: Core Features & Content
 - **Portfolio System:** Not Started
@@ -190,6 +190,13 @@ Status: Awaiting Confirmation
 Progress: Added MainLayout component with responsive header, navigation menu toggle, footer, and integrated into App.vue
 Evidence: backend/resources/js/components/layouts/MainLayout.vue, backend/resources/js/components/App.vue
 Next Steps: Review layout styling and continue building page components
+Updated: 2025-07-20
+
+Task: Create Docker Compose configuration for local development
+Status: Awaiting Confirmation
+Progress: Added Node service to docker-compose for Vite dev server; added python test to validate services
+Evidence: docker-compose.yml, tests/test_docker_compose.py
+Next Steps: Confirm dev setup and create production compose configuration
 Updated: 2025-07-20
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 !/db_data/.gitkeep
 /composer/*
 !/composer/.gitkeep
+
+/tests/__pycache__/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,3 +49,17 @@ services:
     ports:
       - "3306:3306"
 
+  node:
+    image: node:20-alpine
+    container_name: coderstew_node
+    working_dir: /var/www/html
+    volumes:
+      - ./backend:/var/www/html
+    command: sh -c "npm install && npm run dev"
+    environment:
+      NODE_ENV: development
+    ports:
+      - "5173:5173"
+    depends_on:
+      - app
+

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -1,0 +1,18 @@
+import unittest
+import re
+
+class DockerComposeTest(unittest.TestCase):
+    def test_services_exist(self):
+        with open('docker-compose.yml') as f:
+            text = f.read()
+        pattern_app = re.compile(r'^\s*app:', re.MULTILINE)
+        pattern_web = re.compile(r'^\s*web:', re.MULTILINE)
+        pattern_db = re.compile(r'^\s*db:', re.MULTILINE)
+        pattern_node = re.compile(r'^\s*node:', re.MULTILINE)
+        self.assertRegex(text, pattern_app)
+        self.assertRegex(text, pattern_web)
+        self.assertRegex(text, pattern_db)
+        self.assertRegex(text, pattern_node)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- update scratchpad Infrastructure status to In Progress
- create Docker Compose test
- ignore Python cache
- add Node service for Vite dev server in docker-compose

## Testing
- `python3 -m unittest tests/test_docker_compose.py -v`
- `php artisan test` *(fails: missing vendor/autoload)*

------
https://chatgpt.com/codex/tasks/task_e_687d2b2b2d588333b86e256fe67f2db1